### PR TITLE
Fail fast when a non-Steam game has no local image

### DIFF
--- a/app/cmd/collectGameData.go
+++ b/app/cmd/collectGameData.go
@@ -172,6 +172,15 @@ func cmdCollectGameData(cmd *cobra.Command, args []string) error {
 			// Lets handle those images as normal images and copy them into the images folder.
 			if !strings.HasPrefix(gameInfo.Image, imageFolder+"/") {
 
+				// A non-Steam game (SteamID == 0) must ship a local cover image via the
+				// YAML 'image' field. Without it, filepath.Abs("") below resolves to the
+				// current working directory and CopyFile fails deep inside io.Copy with a
+				// confusing "copy_file_range: is a directory" error. Fail fast with an
+				// actionable message instead.
+				if len(gameInfo.Image) == 0 {
+					return fmt.Errorf("game %q has SteamID 0 and no local 'image' field set in YAML; add an image at games/images/<slug>.<ext> and set 'image: ../games/images/<slug>.<ext>' in the YAML", gameInfo.Name)
+				}
+
 				jsonFileExtension := path.Ext(f.Name())
 				imageFileExtension := path.Ext(gameInfo.Image)
 				imageFileName := f.Name()[0:len(f.Name())-len(jsonFileExtension)] + imageFileExtension


### PR DESCRIPTION
## Summary
- CI on `main` fails on `oort.json` with `copy failed: write .../generated/images/oort: copy_file_range: is a directory`.
- Root cause: `oort.yml` has `steamID: 0` but no `image:` field. In `app/cmd/collectGameData.go`, the non-Steam branch then calls `filepath.Abs("")`, which resolves to the current working directory. `CopyFile` creates an empty destination file `oort` and `io.Copy` fails with the cryptic `copy_file_range: is a directory` error.
- This PR adds an early guard in the `SteamID == 0` branch that returns a clear, actionable error pointing contributors at the missing YAML field and the expected `games/images/<slug>.<ext>` location.

This does **not** fix the failing `oort` build itself — that requires adding `games/images/oort.<ext>` and an `image:` line to `games/oort.yml` (mirroring `games/artifacts.yml`). The maintainer needs to supply the actual cover artwork.

## Test plan
- [ ] `cd app && go build ./...` succeeds
- [ ] Run `./awesome-software-engineering-games collectGameData --json-directory ../generated` against a `generated/oort.json` with empty `image` and confirm the new error message appears (instead of `copy_file_range: is a directory`)
- [ ] After adding `games/images/oort.<ext>` and the `image:` field to `games/oort.yml`, re-run the pipeline and confirm `generated/images/oort.<ext>` is produced and `generated/oort.json` has `"image": "images/oort.<ext>"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)