### PR TITLE
Default missing YAML 'image' to a placeholder with a warning

### DIFF
--- a/app/cmd/convertYamlToJson.go
+++ b/app/cmd/convertYamlToJson.go
@@ -14,6 +14,12 @@ import (
 	"github.com/EngineeringKiosk/awesome-software-engineering-games/io"
 )
 
+// defaultGameImage is the placeholder image used when a non-Steam game's YAML
+// file does not specify an 'image' field. The path is expressed relative to the
+// 'generated/' folder, matching the convention used by manually authored entries
+// such as games/artifacts.yml.
+const defaultGameImage = "../assets/dummy-image.png"
+
 // convertYamlToJsonCmd represents the convertYamlToJson command
 var convertYamlToJsonCmd = &cobra.Command{
 	Use:   "convertYamlToJson",
@@ -112,6 +118,15 @@ func cmdConvertYamlToJson(cmd *cobra.Command, args []string) error {
 
 		// Add generated fields
 		gameInfo.Slug = slug.Make(gameInfo.Name)
+
+		// Non-Steam games (SteamID == 0) carry their cover artwork via the YAML
+		// 'image' field. If that field is missing, fall back to a checked-in
+		// placeholder so the pipeline can complete, and surface a warning so the
+		// gap is visible in CI output.
+		if gameInfo.SteamID == 0 && len(gameInfo.Image) == 0 {
+			log.Printf("WARNING: %s has no 'image' field set in YAML; falling back to default %s. Add a real cover at games/images/<slug>.<ext> and set 'image: ../games/images/<slug>.<ext>' in the YAML to replace it.", absYamlFilePath, defaultGameImage)
+			gameInfo.Image = defaultGameImage
+		}
 
 		// Dump data into JSON file
 		log.Printf("Write %s to disk ...", absJsonFilePath)


### PR DESCRIPTION
## Summary
- When a non-Steam game (`steamID: 0`) is added without an `image:` field in its YAML — as just happened with `games/oort.yml` — the pipeline previously failed deep inside `collectGameData` with `copy_file_range: is a directory`.
- This change defaults `gameInfo.Image` to the existing checked-in placeholder `assets/dummy-image.png` at the YAML→JSON boundary in `app/cmd/convertYamlToJson.go`, and logs a `WARNING` line naming the offending YAML file plus instructions for replacing the placeholder.
- Behaviour for Steam games and YAMLs that already set `image:` (e.g. `games/artifacts.yml`, `games/spacetraders.yml`) is unchanged.

## Coordination with #47
PR #47 added a hard-error guard in `collectGameData.go` for the same empty-image case. Once both this PR and #47 are merged, that guard becomes unreachable and should be removed in a small follow-up. Order of merge does not matter; they do not conflict.

## Test plan
- [x] `go build ./...` and `go test ./...` pass
- [x] `go run . convertYamlToJson --yaml-directory ../games --json-directory ../generated` logs the expected `WARNING: ../games/oort.yml has no 'image' field ...` line and writes `"image": "../assets/dummy-image.png"` into `generated/oort.json`
- [x] `games/artifacts.yml` (which sets `image: ../games/images/artifacts.png`) is converted without warning and without the default being applied
- [ ] Run the full pipeline in CI and confirm no regressions on existing games

🤖 Generated with [Claude Code](https://claude.com/claude-code)