### PR TITLE
Fetch GitHub license for games with a repository and surface it in the README

### DIFF
--- a/app/cmd/collectGameData.go
+++ b/app/cmd/collectGameData.go
@@ -14,8 +14,10 @@ import (
 	"strings"
 	"time"
 
+	gh "github.com/google/go-github/v66/github"
 	"github.com/spf13/cobra"
 
+	ghutil "github.com/EngineeringKiosk/awesome-software-engineering-games/github"
 	libIO "github.com/EngineeringKiosk/awesome-software-engineering-games/io"
 	"github.com/EngineeringKiosk/awesome-software-engineering-games/steam"
 )
@@ -62,6 +64,7 @@ func cmdCollectGameData(cmd *cobra.Command, args []string) error {
 	log.Printf("%d files found with extension %s in directory %s", len(jsonFiles), libIO.JSONExtension, jsonDir)
 
 	steamClient := steam.NewClient(nil)
+	ghClient := gh.NewClient(nil)
 
 	for _, f := range jsonFiles {
 		absJsonFilePath := filepath.Join(jsonDir, f.Name())
@@ -195,6 +198,34 @@ func cmdCollectGameData(cmd *cobra.Command, args []string) error {
 				}
 
 				gameInfo.Image = filepath.Join(imageFolder, imageFileName)
+			}
+		}
+
+		// Fetch GitHub license info when the repository is hosted on github.com.
+		// We trust GitHub's license detection (any non-empty SPDX ID that isn't
+		// "NOASSERTION"). On transient errors we keep the previously cached value
+		// loaded from the JSON file rather than blanking it.
+		if gameInfo.Repository != "" {
+			owner, repo, ok := ghutil.ParseRepoURL(gameInfo.Repository)
+			if !ok {
+				log.Printf("Skipping license lookup for %s: %q is not a github.com URL", gameInfo.Name, gameInfo.Repository)
+			} else {
+				log.Printf("Requesting 'Repositories.License' from GitHub for %s/%s ...", owner, repo)
+				lic, resp, err := ghClient.Repositories.License(context.Background(), owner, repo)
+				switch {
+				case err == nil:
+					gameInfo.License = &License{
+						SPDXID: lic.GetLicense().GetSPDXID(),
+						Name:   lic.GetLicense().GetName(),
+						URL:    lic.GetHTMLURL(),
+					}
+					log.Printf("Requesting 'Repositories.License' from GitHub for %s/%s ... successful (%s)", owner, repo, gameInfo.License.SPDXID)
+				case resp != nil && resp.StatusCode == http.StatusNotFound:
+					log.Printf("No license detected by GitHub for %s/%s; clearing cached value", owner, repo)
+					gameInfo.License = nil
+				default:
+					log.Printf("WARNING: GitHub license lookup for %s/%s failed: %v. Keeping previously cached license (if any).", owner, repo, err)
+				}
 			}
 		}
 

--- a/app/cmd/collectGameData.go
+++ b/app/cmd/collectGameData.go
@@ -14,7 +14,7 @@ import (
 	"strings"
 	"time"
 
-	gh "github.com/google/go-github/v66/github"
+	gh "github.com/google/go-github/v85/github"
 	"github.com/spf13/cobra"
 
 	ghutil "github.com/EngineeringKiosk/awesome-software-engineering-games/github"

--- a/app/cmd/convertYamlToJson.go
+++ b/app/cmd/convertYamlToJson.go
@@ -160,6 +160,8 @@ func mergeGameInformation(source, target *GameInformation) *GameInformation {
 	}
 	target.Repository = source.Repository
 	target.Programmable = source.Programmable
+	// target.License is intentionally not touched: it is enriched from the
+	// GitHub API in collectGameData and YAML is not a source of truth for it.
 
 	if source.SteamID == 0 {
 		// If there is no SteamID set, we do not have any platform or release date information.

--- a/app/cmd/types.go
+++ b/app/cmd/types.go
@@ -19,9 +19,19 @@ type GameInformation struct {
 	ReleaseDate ReleaseDate `yaml:"release_date" json:"release_date,omitempty"`
 	Image       string      `yaml:"image" json:"image,omitempty"`
 
+	// License is fetched from the GitHub API for games whose Repository field
+	// points at github.com. Cached in the JSON file; never sourced from YAML.
+	License *License `json:"license,omitempty"`
+
 	// German
 	GermanContent  LanguageContent `yaml:"german_content" json:"german_content,omitempty"`
 	EnglishContent LanguageContent `yaml:"english_content" json:"english_content,omitempty"`
+}
+
+type License struct {
+	SPDXID string `json:"spdx_id,omitempty"`
+	Name   string `json:"name,omitempty"`
+	URL    string `json:"url,omitempty"`
 }
 
 type LanguageContent struct {
@@ -56,6 +66,13 @@ func (g GameInformation) GetReleaseDate() string {
 	}
 
 	return ""
+}
+
+// HasOpenSourceLicense reports whether GitHub detected an open source license
+// for this game's repository. We trust GitHub's detection: any non-empty SPDX
+// ID other than the sentinel "NOASSERTION" counts.
+func (g GameInformation) HasOpenSourceLicense() bool {
+	return g.License != nil && g.License.SPDXID != "" && g.License.SPDXID != "NOASSERTION"
 }
 
 func (g GameInformation) GenresAsList() string {

--- a/app/github/repo_url.go
+++ b/app/github/repo_url.go
@@ -1,0 +1,40 @@
+// Package github contains helpers for working with the GitHub API in this
+// project. The actual API calls are issued via github.com/google/go-github;
+// this package only provides small utilities such as URL parsing.
+package github
+
+import (
+	"net/url"
+	"strings"
+)
+
+// ParseRepoURL extracts (owner, repo) from a GitHub HTTPS URL such as
+// https://github.com/rlane/oort3 or https://github.com/rlane/oort3.git.
+//
+// It returns ok=false for any URL that is not on github.com or that does not
+// look like an /<owner>/<repo> path. Callers should treat ok=false as
+// "not a GitHub repository, skip silently".
+func ParseRepoURL(raw string) (owner, repo string, ok bool) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return "", "", false
+	}
+
+	u, err := url.Parse(raw)
+	if err != nil {
+		return "", "", false
+	}
+	if !strings.EqualFold(u.Host, "github.com") {
+		return "", "", false
+	}
+
+	path := strings.Trim(u.Path, "/")
+	path = strings.TrimSuffix(path, ".git")
+
+	parts := strings.Split(path, "/")
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return "", "", false
+	}
+
+	return parts[0], parts[1], true
+}

--- a/app/github/repo_url_test.go
+++ b/app/github/repo_url_test.go
@@ -1,0 +1,34 @@
+package github
+
+import "testing"
+
+func TestParseRepoURL(t *testing.T) {
+	tests := []struct {
+		name      string
+		input     string
+		wantOwner string
+		wantRepo  string
+		wantOK    bool
+	}{
+		{"basic https", "https://github.com/rlane/oort3", "rlane", "oort3", true},
+		{"trailing slash", "https://github.com/rlane/oort3/", "rlane", "oort3", true},
+		{".git suffix", "https://github.com/rlane/oort3.git", "rlane", "oort3", true},
+		{"http scheme", "http://github.com/rlane/oort3", "rlane", "oort3", true},
+		{"mixed case host", "https://GitHub.com/rlane/oort3", "rlane", "oort3", true},
+		{"non-github host", "https://gitlab.com/rlane/oort3", "", "", false},
+		{"only owner", "https://github.com/rlane", "", "", false},
+		{"too many segments", "https://github.com/rlane/oort3/issues", "", "", false},
+		{"empty", "", "", "", false},
+		{"not a url", ":://broken", "", "", false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			owner, repo, ok := ParseRepoURL(tc.input)
+			if owner != tc.wantOwner || repo != tc.wantRepo || ok != tc.wantOK {
+				t.Errorf("ParseRepoURL(%q) = (%q, %q, %v), want (%q, %q, %v)",
+					tc.input, owner, repo, ok, tc.wantOwner, tc.wantRepo, tc.wantOK)
+			}
+		})
+	}
+}

--- a/app/go.mod
+++ b/app/go.mod
@@ -1,16 +1,16 @@
 module github.com/EngineeringKiosk/awesome-software-engineering-games
 
-go 1.25
+go 1.25.0
 
 require (
-	github.com/google/go-github/v66 v66.0.0
+	github.com/google/go-github/v85 v85.0.0
 	github.com/gosimple/slug v1.15.0
 	github.com/spf13/cobra v1.10.2
 	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
-	github.com/google/go-querystring v1.1.0 // indirect
+	github.com/google/go-querystring v1.2.0 // indirect
 	github.com/gosimple/unidecode v1.0.1 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/kr/pretty v0.1.0 // indirect

--- a/app/go.mod
+++ b/app/go.mod
@@ -3,12 +3,14 @@ module github.com/EngineeringKiosk/awesome-software-engineering-games
 go 1.25
 
 require (
+	github.com/google/go-github/v66 v66.0.0
 	github.com/gosimple/slug v1.15.0
 	github.com/spf13/cobra v1.10.2
 	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
+	github.com/google/go-querystring v1.1.0 // indirect
 	github.com/gosimple/unidecode v1.0.1 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/kr/pretty v0.1.0 // indirect

--- a/app/go.sum
+++ b/app/go.sum
@@ -1,11 +1,11 @@
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
-github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
-github.com/google/go-github/v66 v66.0.0 h1:ADJsaXj9UotwdgK8/iFZtv7MLc8E8WBl62WLd/D/9+M=
-github.com/google/go-github/v66 v66.0.0/go.mod h1:+4SO9Zkuyf8ytMj0csN1NR/5OTR+MfqPp8P8dVlcvY4=
-github.com/google/go-querystring v1.1.0 h1:AnCroh3fv4ZBgVIf1Iwtovgjaw/GiKJo8M8yD/fhyJ8=
-github.com/google/go-querystring v1.1.0/go.mod h1:Kcdr2DB4koayq7X8pmAG4sNG59So17icRSOU623lUBU=
+github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
+github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
+github.com/google/go-github/v85 v85.0.0 h1:1+TLFX/akTFXK7o9Z9uAloQGufOn4ySa5DItUM1VWT4=
+github.com/google/go-github/v85 v85.0.0/go.mod h1:jYkBnqN+SzR2A2fGKYfbt6DEEQAyxeK0Q2XpPV9ZFsU=
+github.com/google/go-querystring v1.2.0 h1:yhqkPbu2/OH+V9BfpCVPZkNmUXhb2gBxJArfhIxNtP0=
+github.com/google/go-querystring v1.2.0/go.mod h1:8IFJqpSRITyJ8QhQ13bmbeMBDfmeEJZD5A0egEOmkqU=
 github.com/gosimple/slug v1.15.0 h1:wRZHsRrRcs6b0XnxMUBM6WK1U1Vg5B0R7VkIf1Xzobo=
 github.com/gosimple/slug v1.15.0/go.mod h1:UiRaFH+GEilHstLUmcBgWcI42viBN7mAb818JrYOeFQ=
 github.com/gosimple/unidecode v1.0.1 h1:hZzFTMMqSswvf0LBJZCZgThIZrpDHFXux9KeGmn6T/o=
@@ -24,7 +24,6 @@ github.com/spf13/pflag v1.0.9/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An
 github.com/spf13/pflag v1.0.10 h1:4EBh2KAYBwaONj6b2Ye1GiHfwjqyROoF4RwYO+vPwFk=
 github.com/spf13/pflag v1.0.10/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
-golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/app/go.sum
+++ b/app/go.sum
@@ -1,4 +1,11 @@
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
+github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
+github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/google/go-github/v66 v66.0.0 h1:ADJsaXj9UotwdgK8/iFZtv7MLc8E8WBl62WLd/D/9+M=
+github.com/google/go-github/v66 v66.0.0/go.mod h1:+4SO9Zkuyf8ytMj0csN1NR/5OTR+MfqPp8P8dVlcvY4=
+github.com/google/go-querystring v1.1.0 h1:AnCroh3fv4ZBgVIf1Iwtovgjaw/GiKJo8M8yD/fhyJ8=
+github.com/google/go-querystring v1.1.0/go.mod h1:Kcdr2DB4koayq7X8pmAG4sNG59So17icRSOU623lUBU=
 github.com/gosimple/slug v1.15.0 h1:wRZHsRrRcs6b0XnxMUBM6WK1U1Vg5B0R7VkIf1Xzobo=
 github.com/gosimple/slug v1.15.0/go.mod h1:UiRaFH+GEilHstLUmcBgWcI42viBN7mAb818JrYOeFQ=
 github.com/gosimple/unidecode v1.0.1 h1:hZzFTMMqSswvf0LBJZCZgThIZrpDHFXux9KeGmn6T/o=
@@ -17,6 +24,7 @@ github.com/spf13/pflag v1.0.9/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An
 github.com/spf13/pflag v1.0.10 h1:4EBh2KAYBwaONj6b2Ye1GiHfwjqyROoF4RwYO+vPwFk=
 github.com/spf13/pflag v1.0.10/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/assets/README.template
+++ b/assets/README.template
@@ -38,6 +38,9 @@ A curated list of games for software engineers that have that certain something 
 {{- if $game.Repository }}
 * [Source Code for {{ $game.Name }} @ Source Code Repository]({{ $game.Repository }})
 {{- end }}
+{{- if $game.HasOpenSourceLicense }}
+* License: [{{ $game.License.SPDXID }}]({{ $game.License.URL }})
+{{- end }}
 {{- if $game.SteamID }}
 * [{{ $game.Name }} @ Steam](https://store.steampowered.com/app/{{ $game.SteamID }}/)
 {{- end }}


### PR DESCRIPTION
## Summary

- For any game whose `repository` field points at github.com, query the GitHub API (via `google/go-github`, unauthenticated) for the detected license and cache it in the per-game JSON.
- Render a new `* License: [SPDX](URL)` bullet under the existing repository link in the README, gated on a `HasOpenSourceLicense` helper that trusts GitHub's detection (non-empty SPDX ID, not `NOASSERTION`).
- Add a tiny `app/github` package that just parses `https://github.com/<owner>/<repo>` URLs — no custom HTTP, all API calls go through `go-github`.

Resolves #11.

## Notes

- Unauthenticated API calls only; ~30 games on a monthly cron sits well under the 60 req/hr limit.
- License survives YAML→JSON merges (`mergeGameInformation` deliberately leaves it untouched), so transient GitHub errors don't blank the cached value. A 404 (no license detected) does clear it.
- Non-github.com repository URLs are skipped silently.

## Test plan

- [x] `go build ./...`
- [x] `go test ./...` (URL parser unit tests)
- [x] Live API verification against `rlane/oort3` → `SPDX=GPL-3.0`, name and HTML URL populated
- [ ] CI's existing `collectGameData` step runs on merge and regenerates JSON / README; spot-check that games with GitHub repos (oort, mindustry, screeps-world, screeps-arena, shapez, spacetraders) gain a license bullet

🤖 Generated with [Claude Code](https://claude.com/claude-code)