### PR TITLE
Accept both .yml and .yaml extensions for game files

### DIFF
--- a/.github/workflows/yaml-lint.yml
+++ b/.github/workflows/yaml-lint.yml
@@ -17,5 +17,5 @@ jobs:
       - name: yaml-lint
         uses: ibiqlik/action-yamllint@v3.1.1
         with:
-          file_or_dir: games/*.yml
+          file_or_dir: games/
           config_file: .yamllint.yml

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,7 +37,7 @@ Instead, it provides you with background on the thought process during the crite
 
 :warning: **The main [`README.md`](/README.md) is a rendered version of the data. Do not edit it manually.**
 
-To add a new game, please create a `.yml` file in the [`/games`](/games) directory like `/games/<game-name>.yml`. 
+To add a new game, please create a `.yml` (or `.yaml`) file in the [`/games`](/games) directory like `/games/<game-name>.yml`. 
 Feel free to check out a few other YAML files in that directory to see what it should look like.
 
 | Field                        | Type               | Description                                                                                |

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -9,7 +9,9 @@ If you want to change the `README.md` file, please make your changes to `assets/
 
 ## Extending the *yml* format in `/games`
 
-If you aim to modify (add, change, or remove) a YAML property in the `/games/*.yml`, please ensure that you make this change in all *.yml* files.
+Game files in `/games` may use either the `.yml` or `.yaml` extension; both are loaded by the tooling.
+
+If you aim to modify (add, change, or remove) a YAML property in `/games/*.yml` (or `/games/*.yaml`), please ensure that you make this change in all YAML files.
 
 Our tooling in `/app` also needs adjustment.
 Mainly in

--- a/app/cmd/convertYamlToJson.go
+++ b/app/cmd/convertYamlToJson.go
@@ -59,12 +59,13 @@ func cmdConvertYamlToJson(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	log.Printf("Reading files with extension %s from directory %s", io.YAMLExtension, yamlDir)
-	yamlFiles, err := io.GetAllFilesFromDirectory(yamlDir, io.YAMLExtension)
+	yamlExts := io.GetYAMLExtensions()
+	log.Printf("Reading files with extensions %v from directory %s", yamlExts, yamlDir)
+	yamlFiles, err := io.GetAllFilesFromDirectoryWithExtensions(yamlDir, yamlExts)
 	if err != nil {
 		return err
 	}
-	log.Printf("%d files found with extension %s in directory %s", len(yamlFiles), io.YAMLExtension, yamlDir)
+	log.Printf("%d files found with extensions %v in directory %s", len(yamlFiles), yamlExts, yamlDir)
 
 	log.Printf("Reading files with extension %s from directory %s", io.JSONExtension, jsonDir)
 	jsonFiles, err := io.GetAllFilesFromDirectory(jsonDir, io.JSONExtension)

--- a/app/io/extension.go
+++ b/app/io/extension.go
@@ -1,9 +1,17 @@
 package io
 
 const (
-	YAMLExtension = ".yml"
-	JSONExtension = ".json"
+	YAMLExtension    = ".yml"
+	YAMLExtensionAlt = ".yaml"
+	JSONExtension    = ".json"
 )
+
+func GetYAMLExtensions() []string {
+	return []string{
+		YAMLExtension,
+		YAMLExtensionAlt,
+	}
+}
 
 func GetImageExtensions() []string {
 	return []string{


### PR DESCRIPTION
## Summary

- Game files in `/games` are now loaded if they end in either `.yml` or `.yaml`. Previously only `.yml` was picked up; `.yaml` files were silently ignored by the converter and skipped by the YAML lint workflow.
- Reuses the existing `io.GetAllFilesFromDirectoryWithExtensions` helper — no new file-loading logic — and points the `yaml-lint` workflow at the `games/` directory so it walks both extensions.
- Updates `CONTRIBUTING.md` and `DEVELOPMENT.md` to mention that both extensions are accepted.

## Test plan

- [x] `go build ./...` and `go vet ./...` pass
- [x] `go test ./...` passes
- [x] Manual smoke: ran `convertYamlToJson` against a temp dir containing one `.yml` and one `.yaml` game file — log reports `2 files found with extensions [.yml .yaml]` and both convert to `.json`
- [ ] CI: `YAML lint` workflow runs against `games/` and lints both extensions

🤖 Generated with [Claude Code](https://claude.com/claude-code)